### PR TITLE
GetComponents: use getpwuid instead of USER

### DIFF
--- a/GetComponents
+++ b/GetComponents
@@ -895,7 +895,7 @@ sub write_componentlist_target {
 }
 
 sub process_users {
-    my $user = $ENV{USER};
+    my $user = getpwuid($<);
     my $last = $user;
     foreach my $component (@all_components) {
 


### PR DESCRIPTION
This makes it possible to use GetComponents in docker containers without having to manually set the USER environment variable. getpwid is part of Perl so not a library function.